### PR TITLE
HR-289: the member still has "IsLocked" set to true when we updated the ...

### DIFF
--- a/HRI/Controllers/MembersSurfaceController.cs
+++ b/HRI/Controllers/MembersSurfaceController.cs
@@ -344,7 +344,10 @@ namespace HRI.Controllers
             {
                 var member = Membership.GetUser(model.UserName);
                 if (member.IsLockedOut)
+                {
                     Membership.Provider.UnlockUser(model.UserName);
+                    member = Membership.GetUser(model.UserName);
+                }
                 var tempPassword = member.ResetPassword();
                 member.ChangePassword(tempPassword, model.NewPassword);
                 Membership.UpdateUser(member);

--- a/HRI/Web.config
+++ b/HRI/Web.config
@@ -50,7 +50,11 @@
   </appSettings>
   <connectionStrings>
     <remove name="umbracoDbDSN"/>
+    <!-- PROD SERVER -->
     <add name="umbracoDbDSN" connectionString="server=192.168.100.40;database=HRI;user id=hrinyprod;password=hrinyprodmw" providerName="System.Data.SqlClient"/>
+    <!-- DEV SERVER -->
+    <!-- <add name="umbracoDbDSN" connectionString="server=192.168.100.105;database=HRI;user id=mwood;password=Door3acc3ss2" providerName="System.Data.SqlClient"/> -->
+    
     <!-- <add name="umbracoDbDSN" connectionString="server=23.253.132.105;database=HRI;user id=mwood;password=Door3acc3ss2" providerName="System.Data.SqlClient"/> -->
     <!-- Important: If you're upgrading Umbraco, do not clear the connection string / provider name during your web.config merge. -->
   </connectionStrings>


### PR DESCRIPTION
...user, so it was reflagging the member as locked out.

Signed-off-by: Robert Miller robert.miller@door3.com

@2j2e i also added the DEV connection string (commented out) to the web.config so it will be easy to switch between prod/dev for testing.
