### PR TITLE
Change web.config to point to DEV

### DIFF
--- a/HRI/Web.config
+++ b/HRI/Web.config
@@ -59,7 +59,7 @@
   </appSettings>
   <connectionStrings>
     <remove name="umbracoDbDSN" />
-    <add name="umbracoDbDSN" connectionString="server=192.168.100.105;database=HRI-UAT;user id=mwood;password=Door3acc3ss2" providerName="System.Data.SqlClient" />
+    <add name="umbracoDbDSN" connectionString="server=192.168.100.105;database=HRI-DEV;user id=mwood;password=Door3acc3ss2" providerName="System.Data.SqlClient" />
     <!-- Important: If you're upgrading Umbraco, do not clear the connection string / provider name during your web.config merge. -->
   </connectionStrings>
   <system.data>


### PR DESCRIPTION
Signed-off-by: bob bob@bobtrix.com

@2j2e I'm assuming we should change the web.config to point to DEV rather than UAT (it also fixed the header issue we were having earlier).  I'll let you merge this.
